### PR TITLE
Balanced allocation, Docs, Const vals, abstract Object class

### DIFF
--- a/object.h
+++ b/object.h
@@ -1,27 +1,29 @@
-//lang::CwC
+// lang::CwC
 #pragma once
 
 #include <cstdlib>
 
 /**
  * A class that represents the top of the object hierarchy.
- * author: chasebish */
+ * author: chasebish
+ */
 class Object {
 public:
-  /** CONSTRUCTORS & DESTRUCTORS **/
+  virtual ~Object(){};
 
-  /* Default Object constructor */
-  Object();
+  /**
+   * Determine whether this Object is equal to the given Object.
+   *
+   * @arg o  the other Object
+   * @return whether the other Object is extensionally equal to this
+   */
+  virtual bool equals(const Object *o) const = 0;
 
-  /* Default Object destructor, to be overriden by subclasses */
-  virtual ~Object();
-
-
-  /** VIRTUAL METHODS **/
-
-  /* Returns whether two objects are equal, to be overriden by subclasses */
-  virtual bool equals(Object* const obj);
-
-  /* Returns an object's hash value. Identical objects should have identical hashes */
-  virtual size_t hash();
+  /**
+   * Generates a hash for this Object. Objects which are `equals` must have
+   * identical hash values.
+   *
+   * @return this Object's hash value.
+   */
+  virtual size_t hash() const = 0;
 };

--- a/string.h
+++ b/string.h
@@ -1,49 +1,73 @@
-//lang::CwC
+// lang::CwC
 #pragma once
 
 #include "object.h"
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cstdio> 
 
 /**
- * An immutable String class representing a char*
- * author: chasebish */
+ * A String class representing a char[]
+ * author: chasebish
+ */
 class String : public Object {
 public:
-  /** CONSTRUCTORS & DESTRUCTORS **/
+  /**
+   * Creates a String by copying a string literal.
+   *
+   * @arg s string literal to be used as a source for this String object
+   */
+  String(const char *s);
 
-  /* Creates a String copying s */
-  String(const char* s);
+  /**
+   * Copy constructor.
+   *
+   * @arg s source String object to be copied from
+   */
+  String(const String *s);
 
-  /* Copies a String copying the value from s */
-  String(String* const s);
-
-  /* Clears String from memory */
   ~String();
 
-
-  /** INHERITED METHODS **/
-
-  /* Inherited from Object, generates a hash for a String */
-  size_t hash();
-
-  /* Inherited from Object, checks equality between an String and an Object */
-  bool equals(Object* const obj);
-
-
-  /** STRING METHODS **/
-  
-  /** Compares strings based on alphabetical order
-   * < 0 -> this String is less than String s
-   * = 0 -> this String is equal to String s
-   * > 0 -> this String is greater than String s
+  /**
+   * Inherits the following from parent Object:
+   *
+   * bool equals(const Object *o) const;
+   * size_t hash() const;
    */
-  int cmp(String* const s);
 
-  /* Creates a new String by combining two existing Strings */
-  String* concat(String* const s);
+  /**
+   * Compares strings based on alphabetical order according to the following
+   * ruleset:
+   *   < 0 -> this String is less than String s
+   *   = 0 -> this String is equal to String s
+   *   > 0 -> this String is greater than String s
+   *
+   * @arg s  the String to compare this against
+   * @return an int resulting from applying the above rules
+   */
+  int cmp(const String *s) const;
 
-  /* Returns the current length of the String */
-  size_t size();
+  /**
+   * Concatenates the given String onto this String.
+   *
+   * @arg s  the source String to be concatenated onto this String
+   * @effect mutates this
+   */
+  void concat(const String *s);
+
+  /**
+   * Concatenates the given String onto this String, storing the result in
+   * dest.
+   *
+   * @arg s    the source string to be concatenated onto this
+   * @arg dest the destination for the string resulting from this concatenation
+   */
+  void concat(const String *s, String *dest) const;
+
+  /**
+   * Get the length of this String
+   *
+   * @return the length of this String
+   */
+  int length() const;
 };

--- a/string.h
+++ b/string.h
@@ -52,15 +52,15 @@ public:
    * @arg s  the String to compare this against
    * @return an int resulting from applying the above rules
    */
-  int cmp(const String *s) const;
+  int compare(const String *s) const;
 
   /**
-   * Concatenates the given String onto this String.
+   * Appends the given String onto this String.
    *
-   * @arg s  the source String to be concatenated onto this String
+   * @arg s  the source String to be appended onto this String
    * @effect mutates this
    */
-  void concat(const String *s);
+  void append(const String *s);
 
   /**
    * Concatenates the given String onto this String, storing the result in

--- a/string.h
+++ b/string.h
@@ -13,6 +13,13 @@
 class String : public Object {
 public:
   /**
+   * Creates an empty string of the requested size.
+   *
+   * @arg s string literal to be used as a source for this String object
+   */
+  String(int size);
+
+  /**
    * Creates a String by copying a string literal.
    *
    * @arg s string literal to be used as a source for this String object


### PR DESCRIPTION
# Description
## String class no longer immutable, but `concat` no longer returns allocate memory
This is about memory safety, there are now two `concat` methods. One mutates and that is called out in an `@effect` tag in the documentation, as well as being non-`const`, and the other uses a non-`const` `String *dest` to write into. This allows the idiom of only freeing memory which you have allocated, which leads to more memory safe code.

<details><summary>Example</summary>

```c++
// 3 news, matched with 3 deletes
const String *h = new String("hello"); // 1 allocated
const String *w = new String("world"); // 2 allocated
String *dest = new String(""); // 3 allocated
h->concat(w, dest);
String hw("helloworld");
assert(dest->equals(&hw));
delete h; // 2 allocated
delete w; // 1 allocated
delete dest; // 0 allocated
```

Instead of:
```c++
// 2 news, not matched with 2 deletes
const String *h = new String("hello"); // 1 allocated
const String *w = new String("world"); // 2 allocated
String *result = h->concat(w); // 3 allocated
String hw("helloworld");
assert(result->equals(&hw));
delete h; // 2 allocated
delete w; // 1 allocated
delete result; // 0 allocated
```
</details>

## Update documentation to more closely match javadoc style
Just because it was what we were taught in F2/OOD and the instructors seem to use it in lecture

## Update signatures to use const values instead of const pointers
Based on [this research](https://gist.github.com/f82e43c26bc6d8c0f6cd0254a7701c26) it seems like these methods from #5 make more sense with `const` values rather than `const` pointers

## Object is now abstract since does not represent useful information
Since the `Object` interface doesn't provide any useful data and the only equality you could implement is always `true` or referential, it seems like there is more value in forcing subclasses to implement these methods instead of having default implementations in `Object`.

## String `size_t size();` → `int length()`
Size and length mean different things and I'm assuming in the case of strings you are referring to length as is specified in the comment above the method.

Additionally, changed from `size_t` to `int` per the recommendation of the [Google C++ style guide](https://google.github.io/styleguide/cppguide.html#Integer_Types) and the number of signed/unsigned bugs i've encountered.
From [Google Style Guide](https://google.github.io/styleguide/cppguide.html#Integer_Types):
> try to avoid unsigned types (except for representing bitfields or modular arithmetic). Do not use an unsigned type merely to assert that a variable is non-negative.

## Style
Ran the Google C++ code formatter over files