### PR TITLE
Add clone() method to object and string (#12)

### DIFF
--- a/object.h
+++ b/object.h
@@ -1,4 +1,4 @@
-// lang::CwC
+//lang::CwC
 #pragma once
 
 #include <cstdlib>
@@ -7,7 +7,7 @@
  * A class that represents the top of the object hierarchy.
  * author: chasebish */
 class Object {
- public:
+public:
   /** CONSTRUCTORS & DESTRUCTORS **/
 
   /* Default Object constructor */

--- a/object.h
+++ b/object.h
@@ -1,4 +1,4 @@
-//lang::CwC
+// lang::CwC
 #pragma once
 
 #include <cstdlib>
@@ -7,7 +7,7 @@
  * A class that represents the top of the object hierarchy.
  * author: chasebish */
 class Object {
-public:
+ public:
   /** CONSTRUCTORS & DESTRUCTORS **/
 
   /* Default Object constructor */
@@ -22,6 +22,11 @@ public:
   /* Returns whether two objects are equal, to be overriden by subclasses */
   virtual bool equals(Object* const obj);
 
-  /* Returns an object's hash value. Identical objects should have identical hashes */
+  /* Returns an object's hash value. Identical objects should have identical
+   * hashes */
   virtual size_t hash();
+
+  /* Returns a copy of this object. The copy is owned by the caller and they are
+   * responsible for freeing its memory. */
+  virtual Object* clone();
 };

--- a/string.h
+++ b/string.h
@@ -1,16 +1,17 @@
-//lang::CwC
+// lang::CwC
 #pragma once
 
-#include "object.h"
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cstdio> 
+
+#include "object.h"
 
 /**
  * An immutable String class representing a char*
  * author: chasebish */
 class String : public Object {
-public:
+ public:
   /** CONSTRUCTORS & DESTRUCTORS **/
 
   /* Creates a String copying s */
@@ -31,9 +32,12 @@ public:
   /* Inherited from Object, checks equality between an String and an Object */
   bool equals(Object* const obj);
 
+  /* Inherited from Object, creates a new String with the same sequence of
+   * characters */
+  String* clone();
 
   /** STRING METHODS **/
-  
+
   /** Compares strings based on alphabetical order
    * < 0 -> this String is less than String s
    * = 0 -> this String is equal to String s

--- a/string.h
+++ b/string.h
@@ -1,4 +1,4 @@
-// lang::CwC
+//lang::CwC
 #pragma once
 
 #include <cstdio>
@@ -11,7 +11,7 @@
  * An immutable String class representing a char*
  * author: chasebish */
 class String : public Object {
- public:
+public:
   /** CONSTRUCTORS & DESTRUCTORS **/
 
   /* Creates a String copying s */


### PR DESCRIPTION
I think this is a very useful method for the interface, and allows for easier generic containers.

I know some people don't like returning raw pointers, but I think it makes sense here - if you call clone, you should know you're getting a new object.

The "correct" way to do this involves using a different language, IMO, and this is the next-best option.